### PR TITLE
Save and Continue Bug Fix

### DIFF
--- a/class-gp-nested-forms.php
+++ b/class-gp-nested-forms.php
@@ -957,7 +957,7 @@ class GP_Nested_Forms extends GP_Plugin {
 
 	public function delete_child_entries_on_save_and_continue( $form ) {
 		if ( rgpost( 'gform_save' ) ) {
-			$session = new GPNF_Session( $form );
+			$session = new GPNF_Session( $form['id'] );
 			$session->delete_cookie();
 		}
 	}


### PR DESCRIPTION
delete_child_entries_on_save_and_continue() from class-gp-nested-forms.php was sending in the entire form array, as opposed to just the form ID when instantiating a new session. Modified so it is only sending in the int ID to GPNF_Session instantiation now.